### PR TITLE
Allow for an environment variable to have more verbose logging info

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,4 +5,6 @@ if [ ! -f /.memcached_admin_created ]; then
 	/create_memcached_admin_user.sh
 fi
 
-memcached -u root -S  -l 0.0.0.0
+dbgflg=${MEMCACHED_DEBUG:-""}
+
+memcached $dbgflg -u root -S  -l 0.0.0.0


### PR DESCRIPTION
I'd really like to be able to start up the memcached server with -vv while I try to figure out what's going wrong with my deployment.  I guess we could have a case statement to verify that $MEMCACHE_DEBUG is either an empty string, '-v' or '-vv', but that feels a little heavy.
